### PR TITLE
Rename `setCtrlHumiSampling` to `setCtrlMeasSamplingHumi`.

### DIFF
--- a/DFRobot_BME280.cpp
+++ b/DFRobot_BME280.cpp
@@ -53,7 +53,7 @@ DFRobot_BME280::eStatus_t DFRobot_BME280::begin()
     getCalibrate();
     setCtrlMeasSamplingPress(eSampling_X8);
     setCtrlMeasSamplingTemp(eSampling_X8);
-    setCtrlHumiSampling(eSampling_X8);
+    setCtrlMeasSamplingHumi(eSampling_X8);
     setConfigFilter(eConfigFilter_off);
     setConfigTStandby(eConfigTStandby_125);
     setCtrlMeasMode(eCtrlMeasMode_normal);   // set control measurement mode to make these settings effective
@@ -158,7 +158,7 @@ void DFRobot_BME280::setCtrlMeasSamplingPress(eSampling_t eSampling)
   writeRegBitsHelper(_sRegs.ctrl_meas, sRegFlied, sRegVal);
 }
 
-void DFRobot_BME280::setCtrlHumiSampling(eSampling_t eSampling)
+void DFRobot_BME280::setCtrlMeasSamplingHumi(eSampling_t eSampling)
 {
   sRegCtrlHum_t   sRegFlied = {0}, sRegVal = {0};
   // sRegFlied.osrs_h = 0xff;

--- a/DFRobot_BME280.h
+++ b/DFRobot_BME280.h
@@ -286,11 +286,11 @@ public:
   void    setCtrlMeasSamplingPress(eSampling_t eSampling);
 
   /**
-   * @fn setCtrlHumiSampling
-   * @brief setCtrlHumiSampling Set control measure humidity oversampling
+   * @fn setCtrlMeasSamplingHumi
+   * @brief setCtrlMeasSamplingHumi Set control measure humidity oversampling
    * @param eSampling One enum of eSampling_t
    */
-  void    setCtrlHumiSampling(eSampling_t eSampling);
+  void    setCtrlMeasSamplingHumi(eSampling_t eSampling);
 
   /**
    * @fn setConfigFilter

--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ There two methods:
   void    setCtrlMeasSamplingPress(eSampling_t eSampling);
 
   /**
-   * @fn setCtrlHumiSampling
-   * @brief setCtrlHumiSampling Set control measure humidity oversampling
+   * @fn setCtrlMeasSamplingHumi
+   * @brief setCtrlMeasSamplingHumi Set control measure humidity oversampling
    * @param eSampling One enum of eSampling_t
    */
-  void    setCtrlHumiSampling(eSampling_t eSampling);
+  void    setCtrlMeasSamplingHumi(eSampling_t eSampling);
 
   /**
    * @fn setConfigFilter

--- a/README_CN.md
+++ b/README_CN.md
@@ -114,11 +114,11 @@ Gravity I2C BME280环境传感器使用BOSCH最新MEMS微机电传感器，具�
   void    setCtrlMeasSamplingPress(eSampling_t eSampling);
 
   /**
-   * @fn setCtrlHumiSampling
+   * @fn setCtrlMeasSamplingHumi
    * @brief 设置控制测量湿度过采样
    * @param eSampling - 枚举量 eSampling_t
    */
-  void    setCtrlHumiSampling(eSampling_t eSampling);
+  void    setCtrlMeasSamplingHumi(eSampling_t eSampling);
 
   /**
    * @fn setConfigFilter

--- a/examples/config/config.ino
+++ b/examples/config/config.ino
@@ -47,7 +47,7 @@ void setup()
   bme.setConfigTStandby(BME::eConfigTStandby_125);    // set standby time
   bme.setCtrlMeasSamplingTemp(BME::eSampling_X8);     // set temperature over sampling
   bme.setCtrlMeasSamplingPress(BME::eSampling_X8);    // set pressure over sampling
-  bme.setCtrlHumiSampling(BME::eSampling_X8);         // set humidity over sampling
+  bme.setCtrlMeasSamplingHumi(BME::eSampling_X8);         // set humidity over sampling
   bme.setCtrlMeasMode(BME::eCtrlMeasMode_normal);     // set control measurement mode to make these settings effective
 
   delay(100);

--- a/keywords.txt
+++ b/keywords.txt
@@ -20,7 +20,7 @@ getHumidity	KEYWORD2
 calAltitude	KEYWORD2
 reset	KEYWORD2
 setCtrlMeasMode	KEYWORD2
-setCtrlHumiSampling	KEYWORD2
+setCtrlMeasSamplingHumi	KEYWORD2
 setCtrlMeasSamplingTemp	KEYWORD2
 setCtrlMeasSamplingPress	KEYWORD2
 setConfigFilter	KEYWORD2


### PR DESCRIPTION
Standardize naming for humidity sampling function for consistency with other measurement functions. Updated references across codebase, documentation, and examples to reflect the new name.